### PR TITLE
Fix label semantics, missing imports, and naming inconsistencies

### DIFF
--- a/governance/materializers/dataframe_materializer.py
+++ b/governance/materializers/dataframe_materializer.py
@@ -72,18 +72,6 @@ class EnhancedDataFrameMaterializer(BaseMaterializer):
         with fileio.open(os.path.join(self.uri, "data.parquet"), "wb") as f:
             df.to_parquet(f, index=False)
 
-        # Save governance metadata
-        # Note: ZenML's artifact system automatically extracts metadata
-        # from materializers for logging and tracking
-        _metadata = {
-            "shape": df.shape,
-            "columns": df.columns.tolist(),
-            "dtypes": df.dtypes.astype(str).to_dict(),
-            "memory_bytes": df.memory_usage(deep=True).sum(),
-            "missing_values": df.isnull().sum().to_dict(),
-            "missing_percentage": (df.isnull().sum() / len(df) * 100).to_dict()
-            if len(df) > 0
-            else {},
-        }
-        # TODO: Return metadata when ZenML supports it in materializers
+        # Extract governance metadata via ZenML's built-in mechanism
+        # The extract_metadata method populates artifact metadata automatically
         self.extract_metadata(df)

--- a/governance/steps/training_report.py
+++ b/governance/steps/training_report.py
@@ -26,6 +26,7 @@ Inspired by zenml-gitflow's model appraisal pattern.
 
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Annotated
 
 import pandas as pd

--- a/scripts/build_snapshot.py
+++ b/scripts/build_snapshot.py
@@ -57,7 +57,7 @@ from zenml.logger import get_logger
 
 logger = get_logger(__name__)
 
-SNAPSHOT_PREFIX = "readmission_model"
+SNAPSHOT_PREFIX = "breast_cancer_classifier"
 
 
 def get_snapshot_name(

--- a/scripts/promote_cross_workspace.py
+++ b/scripts/promote_cross_workspace.py
@@ -58,17 +58,16 @@ Environment Variables (can also be set in .env file):
 
 import json
 import os
-import sys
-from pathlib import Path
-
-# Add project root to Python path for imports
-project_root = Path(__file__).parent.parent
-sys.path.insert(0, str(project_root))
 import subprocess
+import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+
+# Add project root to Python path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
 
 import click
 import joblib
@@ -442,8 +441,9 @@ def validate_for_promotion(manifest: dict, dest_workspace: str) -> bool:
     metrics = manifest.get("metrics", {})
 
     # Define requirements per destination
+    # Note: "enterprise-dev-staging" is the actual workspace name in 2-workspace architecture
     requirements = {
-        "enterprise-staging": {
+        "enterprise-dev-staging": {
             "accuracy": 0.70,
             "precision": 0.70,
             "recall": 0.70,

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -12,8 +12,13 @@ echo "🚀 Setting up ZenML Enterprise MLOps Template..."
 # Check if virtual environment is active
 if [ -z "$VIRTUAL_ENV" ]; then
     echo "⚠️  Warning: No virtual environment detected."
-    echo "   Please activate your virtual environment first:"
-    echo "   source /Users/htahir1/Envs/zenml_enterprise_mlops/bin/activate"
+    echo "   Please create and activate a virtual environment first:"
+    echo ""
+    echo "   # Option 1: Using venv"
+    echo "   python -m venv .venv && source .venv/bin/activate"
+    echo ""
+    echo "   # Option 2: Using uv"
+    echo "   uv venv && source .venv/bin/activate"
     exit 1
 fi
 

--- a/src/pipelines/batch_inference.py
+++ b/src/pipelines/batch_inference.py
@@ -66,13 +66,15 @@ def scale_and_predict(
     )
 
     # Generate predictions
+    # After label inversion in data_loader: 1=high-risk, 0=low-risk
+    # So predict_proba()[:, 1] = high-risk probability
     predictions = model.predict(X_scaled)
     probabilities = model.predict_proba(X_scaled)[:, 1]
 
     results = pd.DataFrame(
         {
-            "prediction": predictions,
-            "probability": probabilities,
+            "high_risk": predictions,
+            "high_risk_probability": probabilities,
         },
         index=X.index,
     )

--- a/src/pipelines/realtime_inference.py
+++ b/src/pipelines/realtime_inference.py
@@ -190,16 +190,17 @@ def predict(
     if scaler is not None:
         features = scaler.transform(features)
     prediction = int(model.predict(features)[0])
-    probability = float(model.predict_proba(features)[0, 1])
+    # After label inversion in data_loader: 1=high-risk, 0=low-risk
+    # So predict_proba()[:, 1] = high-risk probability
+    high_risk_prob = float(model.predict_proba(features)[0, 1])
 
-    # Determine risk level
-    # Note: probability is P(benign), so low probability = high risk
-    if probability > 0.7:
-        risk_level = "LOW"
-    elif probability > 0.4:
+    # Determine risk level based on high-risk probability
+    if high_risk_prob >= 0.7:
+        risk_level = "HIGH"
+    elif high_risk_prob >= 0.3:
         risk_level = "MEDIUM"
     else:
-        risk_level = "HIGH"
+        risk_level = "LOW"
 
     # Simple feature importance explanation
     raw_data = processed_features["raw"]
@@ -225,7 +226,7 @@ def predict(
     return PredictionResult(
         patient_id=str(uuid.uuid4())[:8],
         prediction=prediction,
-        probability=round(probability, 4),
+        probability=round(high_risk_prob, 4),
         risk_level=risk_level,
         model_version=version,
         explanation=explanation,

--- a/src/steps/data_loader.py
+++ b/src/steps/data_loader.py
@@ -52,10 +52,13 @@ def load_data(
     logger.info("Loading breast cancer dataset as proxy for patient risk data")
 
     # Load dataset - this is a proper binary classification dataset
+    # sklearn breast cancer: 0=malignant, 1=benign
+    # We invert so: 1=malignant/high-risk, 0=benign/low-risk
+    # This makes predict_proba()[:, 1] = "high-risk probability"
     data = load_breast_cancer(as_frame=True)
     X = data.data
-    y = data.target
-    y = pd.Series(y, name="risk_prediction")
+    y = 1 - data.target  # Invert: 1=high-risk (malignant), 0=low-risk (benign)
+    y = pd.Series(y, name="high_risk")
 
     logger.info(f"Dataset loaded: {X.shape[0]} patients, {X.shape[1]} features")
     logger.info(f"Target distribution: {y.value_counts().to_dict()}")

--- a/src/steps/feature_engineering.py
+++ b/src/steps/feature_engineering.py
@@ -20,7 +20,8 @@ from typing import Annotated
 
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
-from zenml import step
+from zenml import ArtifactConfig, step
+from zenml.enums import ArtifactType
 from zenml.logger import get_logger
 
 logger = get_logger(__name__)
@@ -33,7 +34,10 @@ def engineer_features(
 ) -> tuple[
     Annotated[pd.DataFrame, "X_train_scaled"],
     Annotated[pd.DataFrame, "X_test_scaled"],
-    Annotated[StandardScaler, "scaler"],
+    Annotated[
+        StandardScaler,
+        ArtifactConfig(name="scaler", artifact_type=ArtifactType.MODEL),
+    ],
 ]:
     """Engineer and scale features for model training.
 

--- a/src/steps/predictor.py
+++ b/src/steps/predictor.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Prediction step for batch inference."""
+"""Prediction step for batch inference (breast cancer risk detection)."""
 
 from typing import Annotated
 
@@ -43,6 +43,8 @@ def predict_batch(
     logger.info(f"Generating predictions for {len(X)} patients")
 
     # Get predictions and probabilities
+    # After label inversion in data_loader: 1=high-risk, 0=low-risk
+    # So predict_proba()[:, 1] = high-risk probability
     predictions = model.predict(X)
     probabilities = model.predict_proba(X)[:, 1]
 
@@ -50,8 +52,8 @@ def predict_batch(
     results = pd.DataFrame(
         {
             "patient_id": X.index,
-            "readmission_risk": predictions,
-            "risk_probability": probabilities,
+            "high_risk": predictions,
+            "high_risk_probability": probabilities,
         }
     )
 


### PR DESCRIPTION
## Summary

Comprehensive bug fixes identified via code review:

- **Fix inverted label semantics** - sklearn breast cancer dataset uses `0=malignant, 1=benign`, but the code was treating `1` as "high risk". This fix inverts labels at load time so `1=high-risk (malignant)` and `predict_proba()[:, 1]` correctly returns high-risk probability
- **Register scaler as model artifact** - Added `ArtifactConfig(artifact_type=ArtifactType.MODEL)` so downstream pipelines can reliably load the scaler from Model Control Plane
- **Fix missing Path import** - `governance/steps/training_report.py` was raising `NameError` when `write_to_file=True`
- **Fix validation key mismatch** - Cross-workspace promotion was using `"enterprise-staging"` but the actual workspace is `"enterprise-dev-staging"`, causing validation to silently skip
- **Fix hardcoded venv path** - Replaced user-specific path in `setup_local.sh` with generic instructions
- **Fix naming inconsistencies** - Updated `SNAPSHOT_PREFIX` and column names from "readmission" to breast cancer terminology

## Test plan

- [x] All 69 existing tests pass
- [ ] Verify label semantics by checking that high `predict_proba()[:, 1]` values correspond to malignant cases
- [ ] Verify scaler artifact appears in Model Control Plane after training
- [ ] Test `generate_training_report` with `write_to_file=True`